### PR TITLE
Fix missing block numbers lookup

### DIFF
--- a/pkg/datastore/postgres/repositories/block_repository.go
+++ b/pkg/datastore/postgres/repositories/block_repository.go
@@ -56,11 +56,11 @@ func (blockRepository BlockRepository) MissingBlockNumbers(startingBlockNumber i
 	numbers := make([]int64, 0)
 	blockRepository.database.Select(&numbers,
 		`SELECT all_block_numbers
-            FROM (
-                SELECT generate_series($1::INT, $2::INT) AS all_block_numbers) series
-                LEFT JOIN blocks
-                    ON number = all_block_numbers
-            WHERE number ISNULL OR eth_node_fingerprint != $3`,
+          FROM (
+              SELECT generate_series($1::INT, $2::INT) AS all_block_numbers) series
+          WHERE all_block_numbers NOT IN (
+		  	  SELECT number FROM blocks WHERE eth_node_fingerprint = $3
+		  ) `,
 		startingBlockNumber,
 		highestBlockNumber, nodeId)
 	return numbers

--- a/pkg/datastore/postgres/repositories/block_repository_test.go
+++ b/pkg/datastore/postgres/repositories/block_repository_test.go
@@ -241,6 +241,23 @@ var _ = Describe("Saving blocks", func() {
 			Expect(len(blockRepository.MissingBlockNumbers(1, 1, node.ID))).To(Equal(0))
 		})
 
+		It("is empty if copies of block exist from both current node and another", func() {
+			blockRepository.CreateOrUpdateBlock(core.Block{Number: 0})
+			blockRepository.CreateOrUpdateBlock(core.Block{Number: 1})
+			nodeTwo := core.Node{
+				GenesisBlock: "0x456",
+				NetworkID:    1,
+			}
+			dbTwo, err := postgres.NewDB(test_config.DBConfig, nodeTwo)
+			Expect(err).NotTo(HaveOccurred())
+			repositoryTwo := repositories.NewBlockRepository(dbTwo)
+			repositoryTwo.CreateOrUpdateBlock(core.Block{Number: 0})
+
+			missing := blockRepository.MissingBlockNumbers(0, 1, node.ID)
+
+			Expect(len(missing)).To(BeZero())
+		})
+
 		It("is the only missing block number", func() {
 			blockRepository.CreateOrUpdateBlock(core.Block{Number: 2})
 


### PR DESCRIPTION
- Previously, a block was treated as missing if there was a number in
the given range for which there existing a block that did not match
the node's fingerprint. This meant that in a case where we have a block
that does not match the node's fingerprint and also one that does match,
the block would be treated as missing. This led to errors being thrown
when attempting to add a block that already exists.
- These changes treat a block as missing only if we do not already have
a block that matches the number and node fingerprint.

Resolves #56 