### PR TITLE
Removed useless goroutines from sync cmd

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -49,9 +49,7 @@ func init() {
 }
 
 func backFillAllBlocks(blockchain core.Blockchain, blockRepository datastore.BlockRepository, missingBlocksPopulated chan int, startingBlockNumber int64) {
-	go func() {
-		missingBlocksPopulated <- history.PopulateMissingBlocks(blockchain, blockRepository, startingBlockNumber)
-	}()
+	missingBlocksPopulated <- history.PopulateMissingBlocks(blockchain, blockRepository, startingBlockNumber)
 }
 
 func sync() {


### PR DESCRIPTION
`backFillAllBlocks` always called with `go func()`:

1. https://github.com/vulcanize/vulcanizedb/blob/master/cmd/sync.go#L74
1. https://github.com/vulcanize/vulcanizedb/blob/master/cmd/sync.go#L82