### PR TITLE
Don't lookup transactions if no log events

### DIFF
--- a/libraries/shared/transactions/syncer.go
+++ b/libraries/shared/transactions/syncer.go
@@ -28,6 +28,9 @@ func NewTransactionsSyncer(db *postgres.DB, blockChain core.BlockChain) Transact
 
 func (syncer TransactionsSyncer) SyncTransactions(headerID int64, logs []types.Log) error {
 	transactionHashes := getUniqueTransactionHashes(logs)
+	if len(transactionHashes) < 1 {
+		return nil
+	}
 	transactions, transactionErr := syncer.BlockChain.GetTransactions(transactionHashes)
 	if transactionErr != nil {
 		return transactionErr

--- a/libraries/shared/transactions/syncer_test.go
+++ b/libraries/shared/transactions/syncer_test.go
@@ -24,10 +24,17 @@ var _ = Describe("Transaction syncer", func() {
 	})
 
 	It("fetches transactions for logs", func() {
-		err := syncer.SyncTransactions(0, []types.Log{})
+		err := syncer.SyncTransactions(0, []types.Log{{TxHash: fakes.FakeHash}})
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(blockChain.GetTransactionsCalled).To(BeTrue())
+	})
+
+	It("does not fetch transactions if no logs", func() {
+		err := syncer.SyncTransactions(0, []types.Log{})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(blockChain.GetTransactionsCalled).To(BeFalse())
 	})
 
 	It("only fetches transactions with unique hashes", func() {
@@ -44,7 +51,7 @@ var _ = Describe("Transaction syncer", func() {
 	It("returns error if fetching transactions fails", func() {
 		blockChain.GetTransactionsError = fakes.FakeError
 
-		err := syncer.SyncTransactions(0, []types.Log{})
+		err := syncer.SyncTransactions(0, []types.Log{{TxHash: fakes.FakeHash}})
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(fakes.FakeError))
@@ -55,7 +62,7 @@ var _ = Describe("Transaction syncer", func() {
 		mockHeaderRepository := fakes.NewMockHeaderRepository()
 		syncer.Repository = mockHeaderRepository
 
-		err := syncer.SyncTransactions(0, []types.Log{})
+		err := syncer.SyncTransactions(0, []types.Log{{TxHash: fakes.FakeHash}})
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mockHeaderRepository.CreateTransactionsCalled).To(BeTrue())
@@ -67,7 +74,7 @@ var _ = Describe("Transaction syncer", func() {
 		mockHeaderRepository.CreateTransactionsError = fakes.FakeError
 		syncer.Repository = mockHeaderRepository
 
-		err := syncer.SyncTransactions(0, []types.Log{})
+		err := syncer.SyncTransactions(0, []types.Log{{TxHash: fakes.FakeHash}})
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(fakes.FakeError))

--- a/pkg/geth/blockchain.go
+++ b/pkg/geth/blockchain.go
@@ -18,7 +18,6 @@ package geth
 
 import (
 	"errors"
-	"fmt"
 	"github.com/ethereum/go-ethereum"
 	"math/big"
 	"strconv"
@@ -122,7 +121,6 @@ func (blockChain *BlockChain) GetTransactions(transactionHashes []common.Hash) (
 
 	rpcErr := blockChain.rpcClient.BatchCall(batch)
 	if rpcErr != nil {
-		fmt.Println("rpc err")
 		return []core.TransactionModel{}, rpcErr
 	}
 


### PR DESCRIPTION
- Prevents EOF error on transactions lookup