### PR TITLE
(VDB-570) Handle duplicate storage diffs

### DIFF
--- a/cmd/composeAndExecute.go
+++ b/cmd/composeAndExecute.go
@@ -193,5 +193,5 @@ func composeAndExecute() {
 func init() {
 	rootCmd.AddCommand(composeAndExecuteCmd)
 	composeAndExecuteCmd.Flags().BoolVarP(&recheckHeadersArg, "recheck-headers", "r", false, "whether to re-check headers for watched events")
-	composeAndExecuteCmd.Flags().DurationVarP(&queueRecheckInterval, "queue-recheck-interval", "q", 5 * time.Minute, "how often to recheck queued storage diffs")
+	composeAndExecuteCmd.Flags().DurationVarP(&queueRecheckInterval, "queue-recheck-interval", "q", 5*time.Minute, "how often to recheck queued storage diffs")
 }

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -139,7 +139,7 @@ func execute() {
 func init() {
 	rootCmd.AddCommand(executeCmd)
 	executeCmd.Flags().BoolVarP(&recheckHeadersArg, "recheck-headers", "r", false, "whether to re-check headers for watched events")
-	executeCmd.Flags().DurationVarP(&queueRecheckInterval, "queue-recheck-interval", "q", 5 * time.Minute, "how often to recheck queued storage diffs")
+	executeCmd.Flags().DurationVarP(&queueRecheckInterval, "queue-recheck-interval", "q", 5*time.Minute, "how often to recheck queued storage diffs")
 }
 
 type Exporter interface {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,22 +36,22 @@ import (
 )
 
 var (
-	cfgFile             string
-	databaseConfig      config.Database
-	genConfig           config.Plugin
-	ipc                 string
-	levelDbPath         string
+	cfgFile              string
+	databaseConfig       config.Database
+	genConfig            config.Plugin
+	ipc                  string
+	levelDbPath          string
 	queueRecheckInterval time.Duration
-	startingBlockNumber int64
-	storageDiffsPath    string
-	syncAll             bool
-	endingBlockNumber   int64
-	recheckHeadersArg   bool
+	startingBlockNumber  int64
+	storageDiffsPath     string
+	syncAll              bool
+	endingBlockNumber    int64
+	recheckHeadersArg    bool
 )
 
 const (
-	pollingInterval      = 7 * time.Second
-	validationWindow     = 15
+	pollingInterval  = 7 * time.Second
+	validationWindow = 15
 )
 
 var rootCmd = &cobra.Command{

--- a/libraries/shared/storage/utils/errors.go
+++ b/libraries/shared/storage/utils/errors.go
@@ -17,8 +17,11 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 )
+
+var ErrRowExists = errors.New("parsed row for storage diff already exists")
 
 type ErrContractNotFound struct {
 	Contract string

--- a/libraries/shared/watcher/storage_watcher.go
+++ b/libraries/shared/watcher/storage_watcher.go
@@ -78,7 +78,7 @@ func (storageWatcher StorageWatcher) processRow(row utils.StorageDiffRow) {
 		return
 	}
 	executeErr := storageTransformer.Execute(row)
-	if executeErr != nil {
+	if executeErr != nil && executeErr != utils.ErrRowExists {
 		logrus.Warn(fmt.Sprintf("error executing storage transformer: %s", executeErr))
 		queueErr := storageWatcher.Queue.Add(row)
 		if queueErr != nil {
@@ -100,7 +100,7 @@ func (storageWatcher StorageWatcher) processQueue() {
 			continue
 		}
 		executeErr := storageTransformer.Execute(row)
-		if executeErr == nil {
+		if executeErr == nil || executeErr == utils.ErrRowExists {
 			storageWatcher.deleteRow(row.Id)
 		}
 	}

--- a/libraries/shared/watcher/storage_watcher_test.go
+++ b/libraries/shared/watcher/storage_watcher_test.go
@@ -109,6 +109,18 @@ var _ = Describe("Storage Watcher", func() {
 				close(done)
 			})
 
+			It("does not queue row if transformer execution fails because row already exists", func(done Done) {
+				mockTransformer.ExecuteErr = utils.ErrRowExists
+
+				go storageWatcher.Execute(rows, errs, time.Hour)
+
+				Expect(<-errs).To(BeNil())
+				Consistently(func() bool {
+					return mockQueue.AddCalled
+				}).Should(BeFalse())
+				close(done)
+			})
+
 			It("queues row for later processing if transformer execution fails", func(done Done) {
 				mockTransformer.ExecuteErr = fakes.FakeError
 
@@ -179,6 +191,17 @@ var _ = Describe("Storage Watcher", func() {
 			})
 
 			It("deletes row from queue if transformer execution successful", func(done Done) {
+				go storageWatcher.Execute(rows, errs, time.Nanosecond)
+
+				Eventually(func() int {
+					return mockQueue.DeletePassedId
+				}).Should(Equal(row.Id))
+				close(done)
+			})
+
+			It("deletes row from queue if transformer execution errors because row already exists", func(done Done) {
+				mockTransformer.ExecuteErr = utils.ErrRowExists
+
 				go storageWatcher.Execute(rows, errs, time.Nanosecond)
 
 				Eventually(func() int {


### PR DESCRIPTION
- If processing a new diff for a row that already exists in the DB,
  ignore the error without logging or queueing
- If processing a queued diff for a row that already exists, remove
  it from the queue