### PR TITLE
Move changelog and diagram information to contributing.md

### DIFF
--- a/documentation/contributing.md
+++ b/documentation/contributing.md
@@ -3,7 +3,7 @@
 Contributions are welcome! Please open an Issues or Pull Request for any changes.
 
 In addition to core contributions, developers are encouraged to build their own custom transformers which
-can be run together with other custom transformers using the [composeAndExeucte](../../staging/documentation/composeAndExecute.md) command.
+can be run together with other custom transformers using the [composeAndExecute](../../staging/documentation/custom-transformers.md) command.
 
 ## Pull Requests
 - `go fmt` is run as part of `make test` and `make integrationtest`, please make sure to check in the format changes.
@@ -23,12 +23,12 @@ conform to the
 converts timestamped migrations to migrations versioned by an incremented integer.
 
 ## Diagrams
-- Diagrams were created with [draw.io](draw.io).
+- Diagrams were created with [draw.io](https://www.draw.io).
 - To update a diagram:
-  1. Go to [draw.io](draw.io).
+  1. Go to [draw.io](https://www.draw.io).
   1. Click on *File > Open from* and choose the location of the diagram you want to update.
   1. Once open in draw.io, you may update it.
-  1. Export the diagram to this repository's directory and add commit it.
+  1. Export the diagram to this repository's directory and commit it.
 
 
 ## Generating the Changelog

--- a/documentation/contributing.md
+++ b/documentation/contributing.md
@@ -22,4 +22,29 @@ conform to the
 1. Core migrations should be committed in their `goose fix`ed form. To do this, run `make version_migrations` which
 converts timestamped migrations to migrations versioned by an incremented integer.
 
+## Diagrams
+- Diagrams were created with [draw.io](draw.io).
+- To update a diagram:
+  1. Go to [draw.io](draw.io).
+  1. Click on *File > Open from* and choose the location of the diagram you want to update.
+  1. Once open in draw.io, you may update it.
+  1. Export the diagram to this repository's directory and add commit it.
+
+
+## Generating the Changelog
+We use [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator) to generate release Changelogs. To be consistent with previous Changelogs, the following flags should be passed to the command:
+
+```
+--user vulcanize
+--project vulcanizedb
+--token {YOUR_GITHUB_TOKEN}
+--no-issues
+--usernames-as-github-logins
+--since-tag {PREVIOUS_RELEASE_TAG}
+```
+
+For more information on why your github token is needed, and how to generate it see [https://github
+.com/github-changelog-generator/github-changelog-generator#github-token](https://github.com/github-changelog-generator/github-changelog-generator#github-token).
+
+## Code of Conduct
 VulcanizeDB follows the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/1/4/code-of-conduct).

--- a/documentation/custom-transformers.md
+++ b/documentation/custom-transformers.md
@@ -2,9 +2,9 @@
 When the capabilities of the generic `contractWatcher` are not sufficient, custom transformers tailored to a specific
 purpose can be leveraged.
 
-Individual custom transformers can be composed together from any number of external repositories and executed as a 
+Individual custom transformers can be composed together from any number of external repositories and executed as a
 single process using the `compose` and `execute` commands or the `composeAndExecute` command. This is accomplished by
-generating a Go plugin which allows the `vulcanizedb` binary to link to the external transformers, so long as they 
+generating a Go plugin which allows the `vulcanizedb` binary to link to the external transformers, so long as they
 abide by one of the standard [interfaces](../staging/libraries/shared/transformer).
 
 ## Writing custom transformers


### PR DESCRIPTION
Thought it maybe made more sense for these "repo maintenance" things to be in the contributing doc, but am not super attached to this change.