### PR TITLE
Fix mappings util

### DIFF
--- a/libraries/shared/storage/mappings.go
+++ b/libraries/shared/storage/mappings.go
@@ -47,7 +47,7 @@ const (
 )
 
 func GetMapping(indexOnContract, key string) common.Hash {
-	keyBytes := common.FromHex("0x" + key + indexOnContract)
+	keyBytes := common.FromHex(key + indexOnContract)
 	encoded := crypto.Keccak256(keyBytes)
 	return common.BytesToHash(encoded)
 }

--- a/libraries/shared/storage/mappings_test.go
+++ b/libraries/shared/storage/mappings_test.go
@@ -21,6 +21,16 @@ var _ = Describe("Mappings", func() {
 			expectedStorageKey := common.HexToHash("0xee0c1b59a3856bafbfb8730e7694c4badc271eb5f01ce4a8d7a53d8a6499676f")
 			Expect(storageKey).To(Equal(expectedStorageKey))
 		})
+
+		It("returns same result if value includes hex prefix", func() {
+			indexOfMappingOnContract := storage.IndexZero
+			keyForDesiredValueInMapping := "0x1234567890abcdef"
+
+			storageKey := storage.GetMapping(indexOfMappingOnContract, keyForDesiredValueInMapping)
+
+			expectedStorageKey := common.HexToHash("0xee0c1b59a3856bafbfb8730e7694c4badc271eb5f01ce4a8d7a53d8a6499676f")
+			Expect(storageKey).To(Equal(expectedStorageKey))
+		})
 	})
 
 	Describe("GetNestedMapping", func() {


### PR DESCRIPTION
- Remove hex prefix so that the function can accept keys with or
  without a hex prefix and return the same result

Prevents us from needing to strip the prefix off of input before feeding it to this function