### PR TITLE
Use eventual assertion in contract watcher test

### DIFF
--- a/integration_test/contract_watcher_header_sync_transformer_test.go
+++ b/integration_test/contract_watcher_header_sync_transformer_test.go
@@ -49,17 +49,18 @@ var _ = Describe("contractWatcher headerSync transformer", func() {
 			c, ok := t.Contracts[tusdAddr]
 			Expect(ok).To(Equal(true))
 
-			// TODO: Fix this
-			// This test sometimes randomly fails because
-			// for some reason the starting block number is not updated from
-			// its original value (5197514) to the block number (6194632)
-			// of the earliest header (mocks.MockHeader1) in the repository
-			// It is not clear how this happens without one of the above insertErrs
-			// having been thrown and without any errors thrown during the Init() call
-			Expect(c.StartingBlock).To(Equal(int64(6194632)))
-			Expect(c.Abi).To(Equal(constants.TusdAbiString))
-			Expect(c.Name).To(Equal("TrueUSD"))
-			Expect(c.Address).To(Equal(tusdAddr))
+			Eventually(func() int64 {
+				return c.StartingBlock
+			}).Should(Equal(int64(6194632)))
+			Eventually(func() string {
+				return c.Abi
+			}).Should(Equal(constants.TusdAbiString))
+			Eventually(func() string {
+				return c.Name
+			}).Should(Equal("TrueUSD"))
+			Eventually(func() string {
+				return c.Address
+			}).Should(Equal(tusdAddr))
 		})
 
 		It("Fails to initialize if first and block cannot be fetched from vDB headers table", func() {


### PR DESCRIPTION
hopefully resolves #100 