### PR TITLE
Removes _checked from column name query

### DIFF
--- a/libraries/shared/repository/repository.go
+++ b/libraries/shared/repository/repository.go
@@ -76,7 +76,8 @@ func GetCheckedColumnNames(db *postgres.DB) ([]string, error) {
 		`SELECT column_name FROM information_schema.columns
 		WHERE table_schema = 'public'
 			AND table_name = 'checked_headers'
-			AND column_name ~ '_checked';`
+			AND column_name <> 'id'
+			AND column_name <> 'header_id';`
 
 	err := db.Select(&queryResult, columnNamesQuery)
 	if err != nil {

--- a/libraries/shared/repository/repository_test.go
+++ b/libraries/shared/repository/repository_test.go
@@ -295,9 +295,9 @@ var _ = Describe("Repository", func() {
 
 func getExpectedColumnNames() []string {
 	return []string{
-		"column_1_checked",
-		"column_2_checked",
-		"column_3_checked",
-		"column_4_checked",
+		"column_1",
+		"column_2",
+		"column_3",
+		"column_4",
 	}
 }


### PR DESCRIPTION
This change is needed to support Edvard's config refactor. It will remove the "_checked" part of the query and return a collection of column names (transformers) to be used with the new configs here: https://github.com/vulcanize/mcd_transformers/pull/154