### PR TITLE
(VDB-768) Allow addresses in packed slots to be decoded

### DIFF
--- a/libraries/shared/storage/utils/decoder.go
+++ b/libraries/shared/storage/utils/decoder.go
@@ -71,7 +71,7 @@ func decodePackedSlot(raw []byte, packedTypes map[int]ValueType) map[int]string 
 		itemValueBytes := storageSlotData[itemStartingIndex:]
 
 		//decode item's bytes and set in results map
-		decodedValue := decodeIndividualItems(itemValueBytes, itemType)
+		decodedValue := decodeIndividualItem(itemValueBytes, itemType)
 		decodedStorageSlotItems[position] = decodedValue
 
 		//pop last item off raw slot data before moving on
@@ -81,12 +81,12 @@ func decodePackedSlot(raw []byte, packedTypes map[int]ValueType) map[int]string 
 	return decodedStorageSlotItems
 }
 
-func decodeIndividualItems(itemBytes []byte, valueType ValueType) string {
+func decodeIndividualItem(itemBytes []byte, valueType ValueType) string {
 	switch valueType {
-	case Uint48:
+	case Uint48, Uint128:
 		return decodeInteger(itemBytes)
-	case Uint128:
-		return decodeInteger(itemBytes)
+	case Address:
+		return decodeAddress(itemBytes)
 	default:
 		panic(fmt.Sprintf("can't decode unknown type: %d", valueType))
 	}
@@ -98,6 +98,8 @@ func getNumberOfBytes(valueType ValueType) int {
 		return 48 / bitsPerByte
 	case Uint128:
 		return 128 / bitsPerByte
+	case Address:
+		return 20
 	default:
 		panic(fmt.Sprintf("ValueType %d not recognized", valueType))
 	}

--- a/libraries/shared/storage/utils/decoder_test.go
+++ b/libraries/shared/storage/utils/decoder_test.go
@@ -146,5 +146,29 @@ var _ = Describe("Storage decoder", func() {
 			Expect(decodedValues[0]).To(Equal(big.NewInt(0).SetBytes(common.HexToHash("AB54A98CEB1F0AD2").Bytes()).String()))
 			Expect(decodedValues[1]).To(Equal(big.NewInt(0).SetBytes(common.HexToHash("38D7EA4C67FF8E502B6730000").Bytes()).String()))
 		})
+
+		It("decodes address + 2 uint48s", func() {
+			//TODO: replace with real data when available
+			addressHex := "0000000000000000000000000000000000012345"
+			packedStorage := common.HexToHash("00000002a300" + "000000002a30" + addressHex)
+			row := utils.StorageDiffRow{StorageValue: packedStorage}
+			packedTypes := map[int]utils.ValueType{}
+			packedTypes[0] = utils.Address
+			packedTypes[1] = utils.Uint48
+			packedTypes[2] = utils.Uint48
+
+			metadata := utils.StorageValueMetadata{
+				Type:        utils.PackedSlot,
+				PackedTypes: packedTypes,
+			}
+
+			result, err := utils.Decode(row, metadata)
+			decodedValues := result.(map[int]string)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(decodedValues[0]).To(Equal("0x" + addressHex))
+			Expect(decodedValues[1]).To(Equal(big.NewInt(0).SetBytes(common.HexToHash("2a30").Bytes()).String()))
+			Expect(decodedValues[2]).To(Equal(big.NewInt(0).SetBytes(common.HexToHash("2a300").Bytes()).String()))
+		})
 	})
 })


### PR DESCRIPTION
Small supplement to the previous work on decoding packed storage slots. Allows addresses to also be decoded.