### PR TITLE
Vdb 750 add descriptive logging

### DIFF
--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -143,6 +143,7 @@ func prepConfig() {
 	names := viper.GetStringSlice("exporter.transformerNames")
 	transformers := make(map[string]config.Transformer)
 	for _, name := range names {
+		LogWithCommand.Debug("Configuring " + name + " transformer")
 		transformer := viper.GetStringMapString("exporter." + name)
 		p, pOK := transformer["path"]
 		if !pOK || p == "" {

--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -143,7 +143,7 @@ func prepConfig() {
 	names := viper.GetStringSlice("exporter.transformerNames")
 	transformers := make(map[string]config.Transformer)
 	for _, name := range names {
-		LogWithCommand.Debug("Configuring " + name + " transformer")
+		logWithCommand.Debug("Configuring " + name + " transformer")
 		transformer := viper.GetStringMapString("exporter." + name)
 		p, pOK := transformer["path"]
 		if !pOK || p == "" {

--- a/libraries/shared/chunker/chunker_suite_test.go
+++ b/libraries/shared/chunker/chunker_suite_test.go
@@ -17,9 +17,8 @@
 package chunker_test
 
 import (
-	"testing"
-
 	"io/ioutil"
+	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/libraries/shared/factories/event/factories_suite_test.go
+++ b/libraries/shared/factories/event/factories_suite_test.go
@@ -17,9 +17,8 @@
 package event_test
 
 import (
-	"testing"
-
 	"io/ioutil"
+	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/libraries/shared/factories/event/transformer.go
+++ b/libraries/shared/factories/event/transformer.go
@@ -54,7 +54,7 @@ func (transformer Transformer) Execute(logs []core.HeaderSyncLog) error {
 		logrus.Errorf("error persisting %v record: %v", transformerName, err)
 		return err
 	}
-	log.Debug("Persisted log for " + transformerName)
+	logrus.Debug("Persisted log for " + transformerName)
 
 	return nil
 }

--- a/libraries/shared/factories/event/transformer.go
+++ b/libraries/shared/factories/event/transformer.go
@@ -54,6 +54,7 @@ func (transformer Transformer) Execute(logs []core.HeaderSyncLog) error {
 		logrus.Errorf("error persisting %v record: %v", transformerName, err)
 		return err
 	}
+	log.Debug("Persisted log for " + transformerName)
 
 	return nil
 }

--- a/libraries/shared/fetcher/fetcher_suite_test.go
+++ b/libraries/shared/fetcher/fetcher_suite_test.go
@@ -17,9 +17,8 @@
 package fetcher_test
 
 import (
-	"testing"
-
 	"io/ioutil"
+	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/libraries/shared/repository/repository_suite_test.go
+++ b/libraries/shared/repository/repository_suite_test.go
@@ -17,9 +17,8 @@
 package repository_test
 
 import (
-	"testing"
-
 	"io/ioutil"
+	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/libraries/shared/storage/storage_suite_test.go
+++ b/libraries/shared/storage/storage_suite_test.go
@@ -17,9 +17,8 @@
 package storage_test
 
 import (
-	"testing"
-
 	"io/ioutil"
+	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/libraries/shared/watcher/contract_watcher.go
+++ b/libraries/shared/watcher/contract_watcher.go
@@ -22,8 +22,7 @@ package watcher
 
 import (
 	"fmt"
-
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/vulcanize/vulcanizedb/libraries/shared/transformer"
 	"github.com/vulcanize/vulcanizedb/pkg/core"
@@ -57,7 +56,7 @@ func (watcher *ContractWatcher) AddTransformers(inits interface{}) error {
 	for _, contractTransformer := range watcher.Transformers {
 		err := contractTransformer.Init()
 		if err != nil {
-			log.Print("Unable to initialize transformer:", contractTransformer.GetConfig().Name, err)
+			logrus.Print("Unable to initialize transformer:", contractTransformer.GetConfig().Name, err)
 			return err
 		}
 	}
@@ -68,7 +67,7 @@ func (watcher *ContractWatcher) Execute() error {
 	for _, contractTransformer := range watcher.Transformers {
 		err := contractTransformer.Execute()
 		if err != nil {
-			log.Error("Unable to execute transformer:", contractTransformer.GetConfig().Name, err)
+			logrus.Error("Unable to execute transformer:", contractTransformer.GetConfig().Name, err)
 			return err
 		}
 	}

--- a/libraries/shared/watcher/storage_watcher.go
+++ b/libraries/shared/watcher/storage_watcher.go
@@ -18,7 +18,6 @@ package watcher
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -124,7 +123,7 @@ func (storageWatcher StorageWatcher) processRow(diff utils.StorageDiff) {
 		}
 		return
 	}
-	logrus.Debug("Storage diff persisted at block height: " + strconv.Itoa(diff.BlockHeight))
+	logrus.Debugf("Storage diff persisted at block height: %d", diff.BlockHeight)
 }
 
 func (storageWatcher StorageWatcher) processQueue() {

--- a/libraries/shared/watcher/storage_watcher.go
+++ b/libraries/shared/watcher/storage_watcher.go
@@ -18,6 +18,7 @@ package watcher
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -123,7 +124,7 @@ func (storageWatcher StorageWatcher) processRow(diff utils.StorageDiff) {
 		}
 		return
 	}
-	logrus.Debug("Storage diff persisted at block height: " + strconv.Itoa(row.BlockHeight))
+	logrus.Debug("Storage diff persisted at block height: " + strconv.Itoa(diff.BlockHeight))
 }
 
 func (storageWatcher StorageWatcher) processQueue() {

--- a/libraries/shared/watcher/storage_watcher.go
+++ b/libraries/shared/watcher/storage_watcher.go
@@ -121,7 +121,9 @@ func (storageWatcher StorageWatcher) processRow(diff utils.StorageDiff) {
 		if queueErr != nil {
 			logrus.Warn(fmt.Sprintf("error queueing storage diff: %s", queueErr))
 		}
+		return
 	}
+	logrus.Debug("Storage diff persisted at block height: " + strconv.Itoa(row.BlockHeight))
 }
 
 func (storageWatcher StorageWatcher) processQueue() {

--- a/libraries/shared/watcher/watcher_suite_test.go
+++ b/libraries/shared/watcher/watcher_suite_test.go
@@ -20,10 +20,9 @@ import (
 	"io/ioutil"
 	"testing"
 
-	log "github.com/sirupsen/logrus"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 )
 
 func TestShared(t *testing.T) {
@@ -32,5 +31,5 @@ func TestShared(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	log.SetOutput(ioutil.Discard)
+	logrus.SetOutput(ioutil.Discard)
 })

--- a/main.go
+++ b/main.go
@@ -2,22 +2,21 @@ package main
 
 import (
 	"github.com/vulcanize/vulcanizedb/cmd"
-
 	"os"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
-	log.SetFormatter(&log.JSONFormatter{
+	logrus.SetFormatter(&logrus.JSONFormatter{
 		PrettyPrint: true,
 	})
 	file, err := os.OpenFile("vulcanizedb.log",
 		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err == nil {
-		log.SetOutput(file)
+		logrus.SetOutput(file)
 	} else {
-		log.Info("Failed to log to file, using default stderr")
+		logrus.Info("Failed to log to file, using default stderr")
 	}
 
 	cmd.Execute()

--- a/pkg/config/contract.go
+++ b/pkg/config/contract.go
@@ -17,9 +17,13 @@
 package config
 
 import (
+<<<<<<< HEAD
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+=======
+	"github.com/sirupsen/logrus"
+>>>>>>> Removes import alias for logrus
 	"github.com/spf13/viper"
 	"github.com/vulcanize/vulcanizedb/pkg/eth"
 )
@@ -91,16 +95,16 @@ func (contractConfig *ContractConfig) PrepConfig() {
 		var abi string
 		abiInterface, abiOK := transformer["abi"]
 		if !abiOK {
-			log.Warnf("contract %s not configured with an ABI, will attempt to fetch it from Etherscan\r\n", addr)
+			logrus.Warnf("contract %s not configured with an ABI, will attempt to fetch it from Etherscan\r\n", addr)
 		} else {
 			abi, abiOK = abiInterface.(string)
 			if !abiOK {
-				log.Fatal(addr, "transformer `abi` not of type []string")
+				logrus.Fatal(addr, "transformer `abi` not of type []string")
 			}
 		}
 		if abi != "" {
 			if _, abiErr := eth.ParseAbi(abi); abiErr != nil {
-				log.Fatal(addr, "transformer `abi` not valid JSON")
+				logrus.Fatal(addr, "transformer `abi` not valid JSON")
 			}
 		}
 		contractConfig.Abis[strings.ToLower(addr)] = abi
@@ -109,17 +113,17 @@ func (contractConfig *ContractConfig) PrepConfig() {
 		events := make([]string, 0)
 		eventsInterface, eventsOK := transformer["events"]
 		if !eventsOK {
-			log.Warnf("contract %s not configured with a list of events to watch, will watch all events\r\n", addr)
+			logrus.Warnf("contract %s not configured with a list of events to watch, will watch all events\r\n", addr)
 			events = []string{}
 		} else {
 			eventsI, eventsOK := eventsInterface.([]interface{})
 			if !eventsOK {
-				log.Fatal(addr, "transformer `events` not of type []string\r\n")
+				logrus.Fatal(addr, "transformer `events` not of type []string\r\n")
 			}
 			for _, strI := range eventsI {
 				str, strOK := strI.(string)
 				if !strOK {
-					log.Fatal(addr, "transformer `events` not of type []string\r\n")
+					logrus.Fatal(addr, "transformer `events` not of type []string\r\n")
 				}
 				events = append(events, str)
 			}
@@ -130,17 +134,17 @@ func (contractConfig *ContractConfig) PrepConfig() {
 		methods := make([]string, 0)
 		methodsInterface, methodsOK := transformer["methods"]
 		if !methodsOK {
-			log.Warnf("contract %s not configured with a list of methods to poll, will not poll any methods\r\n", addr)
+			logrus.Warnf("contract %s not configured with a list of methods to poll, will not poll any methods\r\n", addr)
 			methods = []string{}
 		} else {
 			methodsI, methodsOK := methodsInterface.([]interface{})
 			if !methodsOK {
-				log.Fatal(addr, "transformer `methods` not of type []string\r\n")
+				logrus.Fatal(addr, "transformer `methods` not of type []string\r\n")
 			}
 			for _, strI := range methodsI {
 				str, strOK := strI.(string)
 				if !strOK {
-					log.Fatal(addr, "transformer `methods` not of type []string\r\n")
+					logrus.Fatal(addr, "transformer `methods` not of type []string\r\n")
 				}
 				methods = append(methods, str)
 			}
@@ -151,17 +155,17 @@ func (contractConfig *ContractConfig) PrepConfig() {
 		eventArgs := make([]string, 0)
 		eventArgsInterface, eventArgsOK := transformer["eventArgs"]
 		if !eventArgsOK {
-			log.Warnf("contract %s not configured with a list of event arguments to filter for, will not filter events for specific emitted values\r\n", addr)
+			logrus.Warnf("contract %s not configured with a list of event arguments to filter for, will not filter events for specific emitted values\r\n", addr)
 			eventArgs = []string{}
 		} else {
 			eventArgsI, eventArgsOK := eventArgsInterface.([]interface{})
 			if !eventArgsOK {
-				log.Fatal(addr, "transformer `eventArgs` not of type []string\r\n")
+				logrus.Fatal(addr, "transformer `eventArgs` not of type []string\r\n")
 			}
 			for _, strI := range eventArgsI {
 				str, strOK := strI.(string)
 				if !strOK {
-					log.Fatal(addr, "transformer `eventArgs` not of type []string\r\n")
+					logrus.Fatal(addr, "transformer `eventArgs` not of type []string\r\n")
 				}
 				eventArgs = append(eventArgs, str)
 			}
@@ -172,17 +176,17 @@ func (contractConfig *ContractConfig) PrepConfig() {
 		methodArgs := make([]string, 0)
 		methodArgsInterface, methodArgsOK := transformer["methodArgs"]
 		if !methodArgsOK {
-			log.Warnf("contract %s not configured with a list of method argument values to poll with, will poll methods with all available arguments\r\n", addr)
+			logrus.Warnf("contract %s not configured with a list of method argument values to poll with, will poll methods with all available arguments\r\n", addr)
 			methodArgs = []string{}
 		} else {
 			methodArgsI, methodArgsOK := methodArgsInterface.([]interface{})
 			if !methodArgsOK {
-				log.Fatal(addr, "transformer `methodArgs` not of type []string\r\n")
+				logrus.Fatal(addr, "transformer `methodArgs` not of type []string\r\n")
 			}
 			for _, strI := range methodArgsI {
 				str, strOK := strI.(string)
 				if !strOK {
-					log.Fatal(addr, "transformer `methodArgs` not of type []string\r\n")
+					logrus.Fatal(addr, "transformer `methodArgs` not of type []string\r\n")
 				}
 				methodArgs = append(methodArgs, str)
 			}
@@ -192,11 +196,11 @@ func (contractConfig *ContractConfig) PrepConfig() {
 		// Get and check startingBlock
 		startInterface, startOK := transformer["startingblock"]
 		if !startOK {
-			log.Fatal(addr, "transformer config is missing `startingBlock` value\r\n")
+			logrus.Fatal(addr, "transformer config is missing `startingBlock` value\r\n")
 		}
 		start, startOK := startInterface.(int64)
 		if !startOK {
-			log.Fatal(addr, "transformer `startingBlock` not of type int\r\n")
+			logrus.Fatal(addr, "transformer `startingBlock` not of type int\r\n")
 		}
 		contractConfig.StartingBlocks[strings.ToLower(addr)] = start
 
@@ -204,13 +208,13 @@ func (contractConfig *ContractConfig) PrepConfig() {
 		var piping bool
 		_, pipeOK := transformer["piping"]
 		if !pipeOK {
-			log.Warnf("contract %s does not have its `piping` set, by default piping is turned off\r\n", addr)
+			logrus.Warnf("contract %s does not have its `piping` set, by default piping is turned off\r\n", addr)
 			piping = false
 		} else {
 			pipingInterface := transformer["piping"]
 			piping, pipeOK = pipingInterface.(bool)
 			if !pipeOK {
-				log.Fatal(addr, "transformer `piping` not of type bool\r\n")
+				logrus.Fatal(addr, "transformer `piping` not of type bool\r\n")
 			}
 		}
 		contractConfig.Piping[strings.ToLower(addr)] = piping

--- a/pkg/config/contract.go
+++ b/pkg/config/contract.go
@@ -17,13 +17,9 @@
 package config
 
 import (
-<<<<<<< HEAD
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-=======
-	"github.com/sirupsen/logrus"
->>>>>>> Removes import alias for logrus
 	"github.com/spf13/viper"
 	"github.com/vulcanize/vulcanizedb/pkg/eth"
 )
@@ -95,16 +91,16 @@ func (contractConfig *ContractConfig) PrepConfig() {
 		var abi string
 		abiInterface, abiOK := transformer["abi"]
 		if !abiOK {
-			logrus.Warnf("contract %s not configured with an ABI, will attempt to fetch it from Etherscan\r\n", addr)
+			log.Warnf("contract %s not configured with an ABI, will attempt to fetch it from Etherscan\r\n", addr)
 		} else {
 			abi, abiOK = abiInterface.(string)
 			if !abiOK {
-				logrus.Fatal(addr, "transformer `abi` not of type []string")
+				log.Fatal(addr, "transformer `abi` not of type []string")
 			}
 		}
 		if abi != "" {
 			if _, abiErr := eth.ParseAbi(abi); abiErr != nil {
-				logrus.Fatal(addr, "transformer `abi` not valid JSON")
+				log.Fatal(addr, "transformer `abi` not valid JSON")
 			}
 		}
 		contractConfig.Abis[strings.ToLower(addr)] = abi
@@ -113,17 +109,17 @@ func (contractConfig *ContractConfig) PrepConfig() {
 		events := make([]string, 0)
 		eventsInterface, eventsOK := transformer["events"]
 		if !eventsOK {
-			logrus.Warnf("contract %s not configured with a list of events to watch, will watch all events\r\n", addr)
+			log.Warnf("contract %s not configured with a list of events to watch, will watch all events\r\n", addr)
 			events = []string{}
 		} else {
 			eventsI, eventsOK := eventsInterface.([]interface{})
 			if !eventsOK {
-				logrus.Fatal(addr, "transformer `events` not of type []string\r\n")
+				log.Fatal(addr, "transformer `events` not of type []string\r\n")
 			}
 			for _, strI := range eventsI {
 				str, strOK := strI.(string)
 				if !strOK {
-					logrus.Fatal(addr, "transformer `events` not of type []string\r\n")
+					log.Fatal(addr, "transformer `events` not of type []string\r\n")
 				}
 				events = append(events, str)
 			}
@@ -134,17 +130,17 @@ func (contractConfig *ContractConfig) PrepConfig() {
 		methods := make([]string, 0)
 		methodsInterface, methodsOK := transformer["methods"]
 		if !methodsOK {
-			logrus.Warnf("contract %s not configured with a list of methods to poll, will not poll any methods\r\n", addr)
+			log.Warnf("contract %s not configured with a list of methods to poll, will not poll any methods\r\n", addr)
 			methods = []string{}
 		} else {
 			methodsI, methodsOK := methodsInterface.([]interface{})
 			if !methodsOK {
-				logrus.Fatal(addr, "transformer `methods` not of type []string\r\n")
+				log.Fatal(addr, "transformer `methods` not of type []string\r\n")
 			}
 			for _, strI := range methodsI {
 				str, strOK := strI.(string)
 				if !strOK {
-					logrus.Fatal(addr, "transformer `methods` not of type []string\r\n")
+					log.Fatal(addr, "transformer `methods` not of type []string\r\n")
 				}
 				methods = append(methods, str)
 			}
@@ -155,17 +151,17 @@ func (contractConfig *ContractConfig) PrepConfig() {
 		eventArgs := make([]string, 0)
 		eventArgsInterface, eventArgsOK := transformer["eventArgs"]
 		if !eventArgsOK {
-			logrus.Warnf("contract %s not configured with a list of event arguments to filter for, will not filter events for specific emitted values\r\n", addr)
+			log.Warnf("contract %s not configured with a list of event arguments to filter for, will not filter events for specific emitted values\r\n", addr)
 			eventArgs = []string{}
 		} else {
 			eventArgsI, eventArgsOK := eventArgsInterface.([]interface{})
 			if !eventArgsOK {
-				logrus.Fatal(addr, "transformer `eventArgs` not of type []string\r\n")
+				log.Fatal(addr, "transformer `eventArgs` not of type []string\r\n")
 			}
 			for _, strI := range eventArgsI {
 				str, strOK := strI.(string)
 				if !strOK {
-					logrus.Fatal(addr, "transformer `eventArgs` not of type []string\r\n")
+					log.Fatal(addr, "transformer `eventArgs` not of type []string\r\n")
 				}
 				eventArgs = append(eventArgs, str)
 			}
@@ -176,17 +172,17 @@ func (contractConfig *ContractConfig) PrepConfig() {
 		methodArgs := make([]string, 0)
 		methodArgsInterface, methodArgsOK := transformer["methodArgs"]
 		if !methodArgsOK {
-			logrus.Warnf("contract %s not configured with a list of method argument values to poll with, will poll methods with all available arguments\r\n", addr)
+			log.Warnf("contract %s not configured with a list of method argument values to poll with, will poll methods with all available arguments\r\n", addr)
 			methodArgs = []string{}
 		} else {
 			methodArgsI, methodArgsOK := methodArgsInterface.([]interface{})
 			if !methodArgsOK {
-				logrus.Fatal(addr, "transformer `methodArgs` not of type []string\r\n")
+				log.Fatal(addr, "transformer `methodArgs` not of type []string\r\n")
 			}
 			for _, strI := range methodArgsI {
 				str, strOK := strI.(string)
 				if !strOK {
-					logrus.Fatal(addr, "transformer `methodArgs` not of type []string\r\n")
+					log.Fatal(addr, "transformer `methodArgs` not of type []string\r\n")
 				}
 				methodArgs = append(methodArgs, str)
 			}
@@ -196,11 +192,11 @@ func (contractConfig *ContractConfig) PrepConfig() {
 		// Get and check startingBlock
 		startInterface, startOK := transformer["startingblock"]
 		if !startOK {
-			logrus.Fatal(addr, "transformer config is missing `startingBlock` value\r\n")
+			log.Fatal(addr, "transformer config is missing `startingBlock` value\r\n")
 		}
 		start, startOK := startInterface.(int64)
 		if !startOK {
-			logrus.Fatal(addr, "transformer `startingBlock` not of type int\r\n")
+			log.Fatal(addr, "transformer `startingBlock` not of type int\r\n")
 		}
 		contractConfig.StartingBlocks[strings.ToLower(addr)] = start
 
@@ -208,13 +204,13 @@ func (contractConfig *ContractConfig) PrepConfig() {
 		var piping bool
 		_, pipeOK := transformer["piping"]
 		if !pipeOK {
-			logrus.Warnf("contract %s does not have its `piping` set, by default piping is turned off\r\n", addr)
+			log.Warnf("contract %s does not have its `piping` set, by default piping is turned off\r\n", addr)
 			piping = false
 		} else {
 			pipingInterface := transformer["piping"]
 			piping, pipeOK = pipingInterface.(bool)
 			if !pipeOK {
-				logrus.Fatal(addr, "transformer `piping` not of type bool\r\n")
+				log.Fatal(addr, "transformer `piping` not of type bool\r\n")
 			}
 		}
 		contractConfig.Piping[strings.ToLower(addr)] = piping

--- a/pkg/datastore/postgres/postgres_suite_test.go
+++ b/pkg/datastore/postgres/postgres_suite_test.go
@@ -17,9 +17,8 @@
 package postgres_test
 
 import (
-	"testing"
-
 	"io/ioutil"
+	"testing"
 
 	log "github.com/sirupsen/logrus"
 

--- a/pkg/eth/blockchain.go
+++ b/pkg/eth/blockchain.go
@@ -18,6 +18,7 @@ package eth
 
 import (
 	"errors"
+
 	"math/big"
 	"strconv"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 
 	"github.com/vulcanize/vulcanizedb/pkg/core"
@@ -58,6 +60,7 @@ func NewBlockChain(ethClient core.EthClient, rpcClient core.RPCClient, node core
 
 func (blockChain *BlockChain) GetBlockByNumber(blockNumber int64) (block core.Block, err error) {
 	gethBlock, err := blockChain.ethClient.BlockByNumber(context.Background(), big.NewInt(blockNumber))
+	logrus.Debug("GetBlockByNumber called with block " + strconv.Itoa(int(blockNumber)))
 	if err != nil {
 		return block, err
 	}
@@ -66,6 +69,7 @@ func (blockChain *BlockChain) GetBlockByNumber(blockNumber int64) (block core.Bl
 
 func (blockChain *BlockChain) GetEthLogsWithCustomQuery(query ethereum.FilterQuery) ([]types.Log, error) {
 	gethLogs, err := blockChain.ethClient.FilterLogs(context.Background(), query)
+	logrus.Debug("GetEthLogsWithCustomQuery called")
 	if err != nil {
 		return []types.Log{}, err
 	}
@@ -73,6 +77,7 @@ func (blockChain *BlockChain) GetEthLogsWithCustomQuery(query ethereum.FilterQue
 }
 
 func (blockChain *BlockChain) GetHeaderByNumber(blockNumber int64) (header core.Header, err error) {
+	logrus.Debug("GetHeaderByNumber called with block " + strconv.Itoa(int(blockNumber)))
 	if blockChain.node.NetworkID == core.KOVAN_NETWORK_ID {
 		return blockChain.getPOAHeader(blockNumber)
 	}
@@ -80,6 +85,7 @@ func (blockChain *BlockChain) GetHeaderByNumber(blockNumber int64) (header core.
 }
 
 func (blockChain *BlockChain) GetHeadersByNumbers(blockNumbers []int64) (header []core.Header, err error) {
+	logrus.Debug("GetHeadersByNumbers called")
 	if blockChain.node.NetworkID == core.KOVAN_NETWORK_ID {
 		return blockChain.getPOAHeaders(blockNumbers)
 	}
@@ -268,5 +274,6 @@ func (blockChain *BlockChain) getPOWHeaders(blockNumbers []int64) (headers []cor
 }
 
 func (blockChain *BlockChain) GetAccountBalance(address common.Address, blockNumber *big.Int) (*big.Int, error) {
+	logrus.Debug("GetAccountBalance called")
 	return blockChain.ethClient.BalanceAt(context.Background(), address, blockNumber)
 }

--- a/pkg/eth/blockchain.go
+++ b/pkg/eth/blockchain.go
@@ -60,7 +60,7 @@ func NewBlockChain(ethClient core.EthClient, rpcClient core.RPCClient, node core
 
 func (blockChain *BlockChain) GetBlockByNumber(blockNumber int64) (block core.Block, err error) {
 	gethBlock, err := blockChain.ethClient.BlockByNumber(context.Background(), big.NewInt(blockNumber))
-	logrus.Debug("GetBlockByNumber called with block " + strconv.Itoa(int(blockNumber)))
+	logrus.Debugf("GetBlockByNumber called with block %d", blockNumber)
 	if err != nil {
 		return block, err
 	}
@@ -77,7 +77,7 @@ func (blockChain *BlockChain) GetEthLogsWithCustomQuery(query ethereum.FilterQue
 }
 
 func (blockChain *BlockChain) GetHeaderByNumber(blockNumber int64) (header core.Header, err error) {
-	logrus.Debug("GetHeaderByNumber called with block " + strconv.Itoa(int(blockNumber)))
+	logrus.Debugf("GetHeaderByNumber called with block %d", blockNumber)
 	if blockChain.node.NetworkID == core.KOVAN_NETWORK_ID {
 		return blockChain.getPOAHeader(blockNumber)
 	}

--- a/pkg/eth/testing/helpers.go
+++ b/pkg/eth/testing/helpers.go
@@ -17,8 +17,7 @@
 package testing
 
 import (
-	log "github.com/sirupsen/logrus"
-
+	"github.com/sirupsen/logrus"
 	"github.com/vulcanize/vulcanizedb/pkg/core"
 	"github.com/vulcanize/vulcanizedb/pkg/eth"
 	"github.com/vulcanize/vulcanizedb/test_config"
@@ -34,7 +33,7 @@ func SampleContract() core.Contract {
 func sampleAbiFileContents() string {
 	abiFileContents, err := eth.ReadAbiFile(test_config.ABIFilePath + "sample_abi.json")
 	if err != nil {
-		log.Fatal(err)
+		logrus.Fatal(err)
 	}
 	return abiFileContents
 }

--- a/pkg/history/history_suite_test.go
+++ b/pkg/history/history_suite_test.go
@@ -17,12 +17,11 @@
 package history_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	"io/ioutil"
 	"testing"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/history/populate_headers.go
+++ b/pkg/history/populate_headers.go
@@ -17,7 +17,7 @@
 package history
 
 import (
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/vulcanize/vulcanizedb/pkg/core"
 	"github.com/vulcanize/vulcanizedb/pkg/datastore"
@@ -27,22 +27,22 @@ import (
 func PopulateMissingHeaders(blockChain core.BlockChain, headerRepository datastore.HeaderRepository, startingBlockNumber int64) (int, error) {
 	lastBlock, err := blockChain.LastBlock()
 	if err != nil {
-		log.Error("PopulateMissingHeaders: Error getting last block: ", err)
+		logrus.Error("PopulateMissingHeaders: Error getting last block: ", err)
 		return 0, err
 	}
 
 	blockNumbers, err := headerRepository.MissingBlockNumbers(startingBlockNumber, lastBlock.Int64(), blockChain.Node().ID)
 	if err != nil {
-		log.Error("PopulateMissingHeaders: Error getting missing block numbers: ", err)
+		logrus.Error("PopulateMissingHeaders: Error getting missing block numbers: ", err)
 		return 0, err
 	} else if len(blockNumbers) == 0 {
 		return 0, nil
 	}
 
-	log.Debug(getBlockRangeString(blockNumbers))
+	logrus.Debug(getBlockRangeString(blockNumbers))
 	_, err = RetrieveAndUpdateHeaders(blockChain, headerRepository, blockNumbers)
 	if err != nil {
-		log.Error("PopulateMissingHeaders: Error getting/updating headers: ", err)
+		logrus.Error("PopulateMissingHeaders: Error getting/updating headers: ", err)
 		return 0, err
 	}
 	return len(blockNumbers), nil

--- a/pkg/history/validation_window.go
+++ b/pkg/history/validation_window.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
+
 	"github.com/vulcanize/vulcanizedb/pkg/core"
 )
 


### PR DESCRIPTION
Added more logging when the following event occur:

- Which transformers are being read from the toml file prior to the plugin exporter
- When a log is run through the converter
- When a log is persisted in a repository
- When an unknown diff key is put in the queue
- When a storage diff is persisted
- When certain RPC calls are made

These two still need to be done once we clarify where and what to log:

- Log found for transformer X (info)
- Emitted SQL statements (debug)
