### PR TITLE
Do nothing on duplicate log insert in contract watcher

### DIFF
--- a/pkg/contract_watcher/shared/repository/event_repository.go
+++ b/pkg/contract_watcher/shared/repository/event_repository.go
@@ -128,7 +128,7 @@ func (r *eventRepository) persistHeaderSyncLogs(logs []types.Log, eventInfo type
 		for i := 0; i < el; i++ {
 			pgStr = pgStr + fmt.Sprintf(", $%d", i+6)
 		}
-		pgStr = pgStr + ")"
+		pgStr = pgStr + ") ON CONFLICT DO NOTHING"
 
 		// Add this query to the transaction
 		_, err = tx.Exec(pgStr, data...)


### PR DESCRIPTION
- Prevents duplicate key constraint violation from blocking the process
  from moving forward on restart.
- If header_id, log_idx, and tx_idx are the same, we can safely do
  nothing since it's definitely the same log - a reorg would cause the
  original header to be replaced with a new ID.

Resolves #140 