### PR TITLE
Increase logging in contract watcher

### DIFF
--- a/pkg/contract_watcher/full/transformer/transformer.go
+++ b/pkg/contract_watcher/full/transformer/transformer.go
@@ -19,6 +19,8 @@ package transformer
 import (
 	"errors"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/vulcanize/vulcanizedb/pkg/config"
 	"github.com/vulcanize/vulcanizedb/pkg/contract_watcher/full/converter"
 	"github.com/vulcanize/vulcanizedb/pkg/contract_watcher/full/retriever"
@@ -106,7 +108,11 @@ func (tr *Transformer) Init() error {
 
 		// Get contract name if it has one
 		var name = new(string)
-		tr.Poller.FetchContractData(tr.Parser.Abi(), contractAddr, "name", nil, name, tr.LastBlock)
+		pollingErr := tr.Poller.FetchContractData(tr.Parser.Abi(), contractAddr, "name", nil, name, tr.LastBlock)
+		if pollingErr != nil {
+			// can't return this error because "name" might not exist on the contract
+			logrus.Warnf("error fetching contract data: %s", pollingErr.Error())
+		}
 
 		// Remove any potential accidental duplicate inputs in arg filter values
 		eventArgs := map[string]bool{}

--- a/pkg/contract_watcher/header/converter/converter.go
+++ b/pkg/contract_watcher/header/converter/converter.go
@@ -132,7 +132,7 @@ func (c *Converter) Convert(logs []gethTypes.Log, event types.Event, headerID in
 
 // Convert the given watched event logs into types.Logs; returns a map of event names to a slice of their converted logs
 func (c *Converter) ConvertBatch(logs []gethTypes.Log, events map[string]types.Event, headerID int64) (map[string][]types.Log, error) {
-	contract := bind.NewBoundContract(common.HexToAddress(c.ContractInfo.Address), c.ContractInfo.ParsedAbi, nil, nil, nil)
+	boundContract := bind.NewBoundContract(common.HexToAddress(c.ContractInfo.Address), c.ContractInfo.ParsedAbi, nil, nil, nil)
 	eventsToLogs := make(map[string][]types.Log)
 	for _, event := range events {
 		eventsToLogs[event.Name] = make([]types.Log, 0, len(logs))
@@ -141,7 +141,7 @@ func (c *Converter) ConvertBatch(logs []gethTypes.Log, events map[string]types.E
 			// If the log is of this event type, process it as such
 			if event.Sig() == log.Topics[0] {
 				values := make(map[string]interface{})
-				err := contract.UnpackLogIntoMap(values, event.Name, log)
+				err := boundContract.UnpackLogIntoMap(values, event.Name, log)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/contract_watcher/header/repository/header_repository_test.go
+++ b/pkg/contract_watcher/header/repository/header_repository_test.go
@@ -137,9 +137,9 @@ var _ = Describe("Repository", func() {
 			h1 := missingHeaders[0]
 			h2 := missingHeaders[1]
 			h3 := missingHeaders[2]
-			Expect(h1.BlockNumber).To(Equal(int64(mocks.MockHeader1.BlockNumber)))
-			Expect(h2.BlockNumber).To(Equal(int64(mocks.MockHeader2.BlockNumber)))
-			Expect(h3.BlockNumber).To(Equal(int64(mocks.MockHeader3.BlockNumber)))
+			Expect(h1.BlockNumber).To(Equal(mocks.MockHeader1.BlockNumber))
+			Expect(h2.BlockNumber).To(Equal(mocks.MockHeader2.BlockNumber))
+			Expect(h3.BlockNumber).To(Equal(mocks.MockHeader3.BlockNumber))
 		})
 
 		It("Returns only contiguous chunks of headers", func() {
@@ -150,8 +150,8 @@ var _ = Describe("Repository", func() {
 			missingHeaders, err := contractHeaderRepo.MissingHeaders(mocks.MockHeader1.BlockNumber, mocks.MockHeader4.BlockNumber, eventIDs[0])
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(missingHeaders)).To(Equal(2))
-			Expect(missingHeaders[0].BlockNumber).To(Equal(int64(mocks.MockHeader1.BlockNumber)))
-			Expect(missingHeaders[1].BlockNumber).To(Equal(int64(mocks.MockHeader2.BlockNumber)))
+			Expect(missingHeaders[0].BlockNumber).To(Equal(mocks.MockHeader1.BlockNumber))
+			Expect(missingHeaders[1].BlockNumber).To(Equal(mocks.MockHeader2.BlockNumber))
 		})
 
 		It("Fails if eventID does not yet exist in check_headers table", func() {
@@ -199,8 +199,8 @@ var _ = Describe("Repository", func() {
 			missingHeaders, err := contractHeaderRepo.MissingHeadersForAll(mocks.MockHeader1.BlockNumber, mocks.MockHeader4.BlockNumber, eventIDs)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(missingHeaders)).To(Equal(2))
-			Expect(missingHeaders[0].BlockNumber).To(Equal(int64(mocks.MockHeader1.BlockNumber)))
-			Expect(missingHeaders[1].BlockNumber).To(Equal(int64(mocks.MockHeader2.BlockNumber)))
+			Expect(missingHeaders[0].BlockNumber).To(Equal(mocks.MockHeader1.BlockNumber))
+			Expect(missingHeaders[1].BlockNumber).To(Equal(mocks.MockHeader2.BlockNumber))
 		})
 
 		It("returns headers after starting header if starting header not missing", func() {

--- a/pkg/contract_watcher/header/retriever/block_retriever_test.go
+++ b/pkg/contract_watcher/header/retriever/block_retriever_test.go
@@ -44,9 +44,12 @@ var _ = Describe("Block Retriever", func() {
 
 	Describe("RetrieveFirstBlock", func() {
 		It("Retrieves block number of earliest header in the database", func() {
-			headerRepository.CreateOrUpdateHeader(mocks.MockHeader1)
-			headerRepository.CreateOrUpdateHeader(mocks.MockHeader2)
-			headerRepository.CreateOrUpdateHeader(mocks.MockHeader3)
+			_, err := headerRepository.CreateOrUpdateHeader(mocks.MockHeader1)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = headerRepository.CreateOrUpdateHeader(mocks.MockHeader2)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = headerRepository.CreateOrUpdateHeader(mocks.MockHeader3)
+			Expect(err).ToNot(HaveOccurred())
 
 			i, err := r.RetrieveFirstBlock()
 			Expect(err).NotTo(HaveOccurred())
@@ -61,9 +64,12 @@ var _ = Describe("Block Retriever", func() {
 
 	Describe("RetrieveMostRecentBlock", func() {
 		It("Retrieves the latest header's block number", func() {
-			headerRepository.CreateOrUpdateHeader(mocks.MockHeader1)
-			headerRepository.CreateOrUpdateHeader(mocks.MockHeader2)
-			headerRepository.CreateOrUpdateHeader(mocks.MockHeader3)
+			_, err := headerRepository.CreateOrUpdateHeader(mocks.MockHeader1)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = headerRepository.CreateOrUpdateHeader(mocks.MockHeader2)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = headerRepository.CreateOrUpdateHeader(mocks.MockHeader3)
+			Expect(err).ToNot(HaveOccurred())
 
 			i, err := r.RetrieveMostRecentBlock()
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/contract_watcher/header/transformer/transformer_test.go
+++ b/pkg/contract_watcher/header/transformer/transformer_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Transformer", func() {
 			err := t.Init()
 
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(fakes.FakeError))
+			Expect(err.Error()).To(ContainSubstring(fakes.FakeError.Error()))
 		})
 	})
 
@@ -109,7 +109,7 @@ var _ = Describe("Transformer", func() {
 			err := t.Init()
 
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(fakes.FakeError))
+			Expect(err.Error()).To(ContainSubstring(fakes.FakeError.Error()))
 		})
 	})
 })

--- a/pkg/contract_watcher/shared/constants/interface.go
+++ b/pkg/contract_watcher/shared/constants/interface.go
@@ -24,7 +24,7 @@ import (
 var SupportsInterfaceABI = `[{"constant":true,"inputs":[{"name":"interfaceID","type":"bytes4"}],"name":"supportsInterface","outputs":[{"name":"","type":"bool"}],"payable":false,"type":"function"}]`
 
 // Individual event interfaces for constructing ABI from
-var SupportsInterace = `{"constant":true,"inputs":[{"name":"interfaceID","type":"bytes4"}],"name":"supportsInterface","outputs":[{"name":"","type":"bool"}],"payable":false,"type":"function"}`
+var SupportsInterface = `{"constant":true,"inputs":[{"name":"interfaceID","type":"bytes4"}],"name":"supportsInterface","outputs":[{"name":"","type":"bool"}],"payable":false,"type":"function"}`
 var AddrChangeInterface = `{"anonymous":false,"inputs":[{"indexed":true,"name":"node","type":"bytes32"},{"indexed":false,"name":"a","type":"address"}],"name":"AddrChanged","type":"event"}`
 var ContentChangeInterface = `{"anonymous":false,"inputs":[{"indexed":true,"name":"node","type":"bytes32"},{"indexed":false,"name":"hash","type":"bytes32"}],"name":"ContentChanged","type":"event"}`
 var NameChangeInterface = `{"anonymous":false,"inputs":[{"indexed":true,"name":"node","type":"bytes32"},{"indexed":false,"name":"name","type":"string"}],"name":"NameChanged","type":"event"}`

--- a/pkg/contract_watcher/shared/fetcher/fetcher.go
+++ b/pkg/contract_watcher/shared/fetcher/fetcher.go
@@ -47,7 +47,7 @@ func newFetcherError(err error, fetchMethod string) *fetcherError {
 
 // Fetcher struct
 type Fetcher struct {
-	BlockChain core.BlockChain // Underyling Blockchain
+	BlockChain core.BlockChain // Underlying Blockchain
 }
 
 // Fetcher error

--- a/pkg/contract_watcher/shared/helpers/test_helpers/database.go
+++ b/pkg/contract_watcher/shared/helpers/test_helpers/database.go
@@ -115,9 +115,9 @@ func SetupDBandBC() (*postgres.DB, core.BlockChain) {
 	rpcClient := client.NewRpcClient(rawRpcClient, infuraIPC)
 	ethClient := ethclient.NewClient(rawRpcClient)
 	blockChainClient := client.NewEthClient(ethClient)
-	node := node.MakeNode(rpcClient)
+	madeNode := node.MakeNode(rpcClient)
 	transactionConverter := rpc2.NewRpcTransactionConverter(ethClient)
-	blockChain := geth.NewBlockChain(blockChainClient, rpcClient, node, transactionConverter)
+	blockChain := geth.NewBlockChain(blockChainClient, rpcClient, madeNode, transactionConverter)
 
 	db, err := postgres.NewDB(config.Database{
 		Hostname: "localhost",

--- a/pkg/contract_watcher/shared/helpers/test_helpers/mocks/entities.go
+++ b/pkg/contract_watcher/shared/helpers/test_helpers/mocks/entities.go
@@ -324,7 +324,7 @@ var MockConfig = config.ContractConfig{
 		"0x1234567890abcdef": "fake_abi",
 	},
 	Events: map[string][]string{
-		"0x1234567890abcdef": []string{"Transfer"},
+		"0x1234567890abcdef": {"Transfer"},
 	},
 	Methods: map[string][]string{
 		"0x1234567890abcdef": nil,

--- a/pkg/contract_watcher/shared/helpers/test_helpers/test_data.go
+++ b/pkg/contract_watcher/shared/helpers/test_helpers/test_data.go
@@ -35,7 +35,7 @@ var TusdConfig = config.ContractConfig{
 		tusd: "",
 	},
 	Events: map[string][]string{
-		tusd: []string{"Transfer"},
+		tusd: {"Transfer"},
 	},
 	Methods: map[string][]string{
 		tusd: nil,
@@ -60,7 +60,7 @@ var ENSConfig = config.ContractConfig{
 		ens: "",
 	},
 	Events: map[string][]string{
-		ens: []string{"NewOwner"},
+		ens: {"NewOwner"},
 	},
 	Methods: map[string][]string{
 		ens: nil,
@@ -87,8 +87,8 @@ var ENSandTusdConfig = config.ContractConfig{
 		tusd: "",
 	},
 	Events: map[string][]string{
-		ens:  []string{"NewOwner"},
-		tusd: []string{"Transfer"},
+		ens:  {"NewOwner"},
+		tusd: {"Transfer"},
 	},
 	Methods: map[string][]string{
 		ens:  nil,

--- a/pkg/contract_watcher/shared/repository/event_repository_test.go
+++ b/pkg/contract_watcher/shared/repository/event_repository_test.go
@@ -190,7 +190,7 @@ var _ = Describe("Repository", func() {
 				}
 				Expect(scanLog).To(Equal(expectedLog))
 
-				// Attempt to persist the same log again in seperate call
+				// Attempt to persist the same log again in separate call
 				err = dataStore.PersistLogs([]types.Log{*log}, event, con.Address, con.Name)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/contract_watcher/shared/repository/method_repository.go
+++ b/pkg/contract_watcher/shared/repository/method_repository.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/golang-lru"
+	"github.com/sirupsen/logrus"
 
 	"github.com/vulcanize/vulcanizedb/pkg/contract_watcher/shared/types"
 	"github.com/vulcanize/vulcanizedb/pkg/datastore/postgres"
@@ -112,7 +113,10 @@ func (r *methodRepository) persistResults(results []types.Result, methodInfo typ
 		// Add this query to the transaction
 		_, err = tx.Exec(pgStr, data...)
 		if err != nil {
-			tx.Rollback()
+			rollbackErr := tx.Rollback()
+			if rollbackErr != nil {
+				logrus.Warnf("error rolling back transaction: %s", rollbackErr.Error())
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
- Focus on header mode
- Add context to errors, trace guard clauses, warn on non-returned
  errors
- Give errors distinct names so compiler will recognize if unchecked
- Remove redundant type declarations/fix typos