### PR TITLE
Add uniqueness constraint to headers

### DIFF
--- a/db/migrations/00023_create_headers_table.sql
+++ b/db/migrations/00023_create_headers_table.sql
@@ -8,7 +8,8 @@ CREATE TABLE public.headers
     block_timestamp      NUMERIC,
     check_count          INTEGER NOT NULL DEFAULT 0,
     eth_node_id          INTEGER NOT NULL REFERENCES eth_nodes (id) ON DELETE CASCADE,
-    eth_node_fingerprint VARCHAR(128)
+    eth_node_fingerprint VARCHAR(128),
+    UNIQUE (block_number, eth_node_fingerprint)
 );
 
 -- Index is removed when table is

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -922,6 +922,14 @@ ALTER TABLE ONLY public.header_sync_transactions
 
 
 --
+-- Name: headers headers_block_number_eth_node_fingerprint_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.headers
+    ADD CONSTRAINT headers_block_number_eth_node_fingerprint_key UNIQUE (block_number, eth_node_fingerprint);
+
+
+--
 -- Name: headers headers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 

--- a/pkg/datastore/postgres/repositories/header_repository_test.go
+++ b/pkg/datastore/postgres/repositories/header_repository_test.go
@@ -84,13 +84,12 @@ var _ = Describe("Block header repository", func() {
 			Expect(ethNodeFingerprint).To(Equal(db.Node.ID))
 		})
 
-		It("returns valid header exists error if attempting duplicate headers", func() {
+		It("does not duplicate headers", func() {
 			_, err = repo.CreateOrUpdateHeader(header)
 			Expect(err).NotTo(HaveOccurred())
 
 			_, err = repo.CreateOrUpdateHeader(header)
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(repositories.ErrValidHeaderExists))
+			Expect(err).NotTo(HaveOccurred())
 
 			var dbHeaders []core.Header
 			err = db.Select(&dbHeaders, `SELECT block_number, hash, raw FROM public.headers WHERE block_number = $1`, header.BlockNumber)

--- a/pkg/history/populate_headers.go
+++ b/pkg/history/populate_headers.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/vulcanize/vulcanizedb/pkg/core"
 	"github.com/vulcanize/vulcanizedb/pkg/datastore"
-	"github.com/vulcanize/vulcanizedb/pkg/datastore/postgres/repositories"
 )
 
 func PopulateMissingHeaders(blockChain core.BlockChain, headerRepository datastore.HeaderRepository, startingBlockNumber int64) (int, error) {
@@ -49,14 +48,14 @@ func PopulateMissingHeaders(blockChain core.BlockChain, headerRepository datasto
 }
 
 func RetrieveAndUpdateHeaders(blockChain core.BlockChain, headerRepository datastore.HeaderRepository, blockNumbers []int64) (int, error) {
-	headers, err := blockChain.GetHeadersByNumbers(blockNumbers)
+	headers, getErr := blockChain.GetHeadersByNumbers(blockNumbers)
+	if getErr != nil {
+		return 0, getErr
+	}
 	for _, header := range headers {
-		_, err = headerRepository.CreateOrUpdateHeader(header)
-		if err != nil {
-			if err == repositories.ErrValidHeaderExists {
-				continue
-			}
-			return 0, err
+		_, insertErr := headerRepository.CreateOrUpdateHeader(header)
+		if insertErr != nil {
+			return 0, insertErr
 		}
 	}
 	return len(blockNumbers), nil


### PR DESCRIPTION
- Only allow one header with a given block number per node fingerprint
- Also inline upsert operation into one query

Resolves #148 

One thing to consider - this change likely causes a lot more writes during verification at the head of the chain (if we've already persisted those headers). Previously, if we saw the same header during verification, we would do nothing. With this approach, we will be doing updates even if the new header has the same hash.

However, the previous approach still required _querying_ every header at the head of the chain to determine whether the hash conflicted. And if there was a conflict, it entailed two additional queries to delete the outdated header and insert the new one. Hoping that reducing the number of database connections in the application code will compensate for additional writes.