### PR TITLE
Add constraint to prevent duplicate headers

### DIFF
--- a/db/migrations/00023_create_headers_table.sql
+++ b/db/migrations/00023_create_headers_table.sql
@@ -8,7 +8,8 @@ CREATE TABLE public.headers
     block_timestamp      NUMERIC,
     check_count          INTEGER NOT NULL DEFAULT 0,
     eth_node_id          INTEGER NOT NULL REFERENCES eth_nodes (id) ON DELETE CASCADE,
-    eth_node_fingerprint VARCHAR(128)
+    eth_node_fingerprint VARCHAR(128),
+    UNIQUE (block_number, hash, eth_node_fingerprint)
 );
 
 -- Index is removed when table is

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -922,6 +922,14 @@ ALTER TABLE ONLY public.header_sync_transactions
 
 
 --
+-- Name: headers headers_block_number_hash_eth_node_fingerprint_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.headers
+    ADD CONSTRAINT headers_block_number_hash_eth_node_fingerprint_key UNIQUE (block_number, hash, eth_node_fingerprint);
+
+
+--
 -- Name: headers headers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 


### PR DESCRIPTION
- Disallow inserts of headers with the same number, hash, and node
  fingerprint, since it will enable duplicate log fetching for the
  same header

Resolves #148 

Minimal change set to prevent concurrent processes from inserting duplicate headers. Would be cool to revisit how we can simplify the application code while preserving our cascade delete functionality (that handles reorgs).

Also important to note that we can still end up with duplicate logs since headers with the same number and hash come from different nodes 🤔 