### PR TITLE
Enable contractWatcher without prior headerSync

### DIFF
--- a/integration_test/contract_watcher_header_sync_transformer_test.go
+++ b/integration_test/contract_watcher_header_sync_transformer_test.go
@@ -78,11 +78,10 @@ var _ = Describe("contractWatcher headerSync transformer", func() {
 			Expect(c.Address).To(Equal(tusdAddr))
 		})
 
-		It("Fails to initialize if first and block cannot be fetched from vDB headers table", func() {
+		It("initializes when no headers available in db", func() {
 			t := transformer.NewTransformer(test_helpers.TusdConfig, blockChain, db)
 			err = t.Init()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("no rows in result set"))
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Does nothing if nothing if no addresses are configured", func() {

--- a/pkg/contract_watcher/header/transformer/transformer.go
+++ b/pkg/contract_watcher/header/transformer/transformer.go
@@ -17,6 +17,7 @@
 package transformer
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
@@ -124,7 +125,11 @@ func (tr *Transformer) Init() error {
 		// Get first block and most recent block number in the header repo
 		firstBlock, retrieveErr := tr.Retriever.RetrieveFirstBlock()
 		if retrieveErr != nil {
-			return fmt.Errorf("error retrieving first block: %s", retrieveErr.Error())
+			if retrieveErr == sql.ErrNoRows {
+				firstBlock = 0
+			} else {
+				return fmt.Errorf("error retrieving first block: %s", retrieveErr.Error())
+			}
 		}
 
 		// Set to specified range if it falls within the bounds

--- a/pkg/contract_watcher/header/transformer/transformer_test.go
+++ b/pkg/contract_watcher/header/transformer/transformer_test.go
@@ -17,6 +17,7 @@
 package transformer_test
 
 import (
+	"database/sql"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -101,7 +102,17 @@ var _ = Describe("Transformer", func() {
 			Expect(c.Address).To(Equal(fakeAddress))
 		})
 
-		It("Fails to initialize if first block cannot be fetched from vDB headers table", func() {
+		It("uses first block from config if vDB headers table has no rows", func() {
+			blockRetriever := &fakes.MockHeaderSyncBlockRetriever{}
+			blockRetriever.FirstBlockErr = sql.ErrNoRows
+			t := getFakeTransformer(blockRetriever, &fakes.MockParser{}, &fakes.MockPoller{})
+
+			err := t.Init()
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error if fetching first block fails for other reason", func() {
 			blockRetriever := &fakes.MockHeaderSyncBlockRetriever{}
 			blockRetriever.FirstBlockErr = fakes.FakeError
 			t := getFakeTransformer(blockRetriever, &fakes.MockParser{}, &fakes.MockPoller{})


### PR DESCRIPTION
- Previous setup would fail if there were no headers in the db. This
  makes sense because we need headers that haven't been checked for
  logs to exist so that we can fetch logs for those headers. But it
  also prevents us from kicking off the headerSync and contractWatcher
  processes concurrently. These changes enable kicking off both
  processes at the same time with the idea that we will have unchecked
  headers upon transformer execution.

Resolves #155 

@i-norden let me know if I'm missing unforeseen risks to enabling concurrent execution - ran into the issue while working on a docker deploy that execute both processes