### PR TITLE
Storage branch decode error

### DIFF
--- a/pkg/ipfs/ipld/trie_node.go
+++ b/pkg/ipfs/ipld/trie_node.go
@@ -138,12 +138,12 @@ func parseTrieNodeExtension(i []interface{}, codec uint64) ([]interface{}, error
 func parseTrieNodeBranch(i []interface{}, codec uint64) ([]interface{}, error) {
 	var out []interface{}
 
-	for _, vi := range i {
+	for i, vi := range i {
 		v, ok := vi.([]byte)
 		// Sometimes this throws "panic: interface conversion: interface {} is []interface {}, not []uint8"
 		// Figure out why, and if it is okay to continue
 		if !ok {
-			continue
+			return nil, fmt.Errorf("unable to decode branch node entry into []byte at position: %d value: %+v", i, vi)
 		}
 
 		switch len(v) {

--- a/pkg/super_node/backfiller.go
+++ b/pkg/super_node/backfiller.go
@@ -132,7 +132,7 @@ func (bfs *BackFillService) BackFill(wg *sync.WaitGroup) {
 					log.Errorf("super node db backfill RetrieveFirstBlockNumber error for chain %s: %v", bfs.Chain.String(), err)
 					continue
 				}
-				if startingBlock != 0 && bfs.Chain == shared.Bitcoin || startingBlock != 1 && bfs.Chain == shared.Ethereum {
+				if startingBlock != 0 {
 					log.Infof("found gap at the beginning of the %s sync", bfs.Chain.String())
 					if err := bfs.backFill(0, uint64(startingBlock-1)); err != nil {
 						log.Error(err)
@@ -199,6 +199,7 @@ func (bfs *BackFillService) backFill(startingBlock, endingBlock uint64) error {
 					cidPayload, err := bfs.Publisher.Publish(ipldPayload)
 					if err != nil {
 						log.Errorf("%s super node historical data publisher error: %s", bfs.Chain.String(), err.Error())
+						continue
 					}
 					if err := bfs.Indexer.Index(cidPayload); err != nil {
 						log.Errorf("%s super node historical data indexer error: %s", bfs.Chain.String(), err.Error())

--- a/pkg/super_node/backfiller_test.go
+++ b/pkg/super_node/backfiller_test.go
@@ -45,7 +45,7 @@ var _ = Describe("BackFiller", func() {
 				ReturnErr:         nil,
 			}
 			mockRetriever := &mocks2.CIDRetriever{
-				FirstBlockNumberToReturn: 1,
+				FirstBlockNumberToReturn: 0,
 				GapsToRetrieve: []shared.Gap{
 					{
 						Start: 100, Stop: 101,
@@ -102,7 +102,7 @@ var _ = Describe("BackFiller", func() {
 				ReturnErr:         nil,
 			}
 			mockRetriever := &mocks2.CIDRetriever{
-				FirstBlockNumberToReturn: 1,
+				FirstBlockNumberToReturn: 0,
 				GapsToRetrieve: []shared.Gap{
 					{
 						Start: 100, Stop: 100,

--- a/pkg/super_node/eth/publisher.go
+++ b/pkg/super_node/eth/publisher.go
@@ -19,12 +19,11 @@ package eth
 import (
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/statediff"
 
 	common2 "github.com/vulcanize/vulcanizedb/pkg/eth/converters/common"


### PR DESCRIPTION
Very rarely we run across a storage diff that would throw an error like:

`FATA[2020-05-11T17:00:30-05:00] eth IPLDPublisherAndIndexer error decoding storage node {Path:[11 0 15 6 11 15 7 0] LeafKey:[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] Value:[248 79 128 128 128 128 128 128 128 160 196 212 95 69 107 210 244 2 38 146 59 101 196 191 130 80 196 7 114 100 97 169 126 215 114 59 112 78 116 111 133 9 128 128 128 128 128 128 222 156 54 67 156 56 255 153 112 176 185 21 62 239 27 79 212 212 90 175 240 252 0 192 203 46 180 91 154 233 1 128 128] Type:Branch} at block 10041344 statekey 0x0f27a427a06c148ea9a08f515db9ba0cdcfc7260580a2e512385db59487acd14 cid bagmacgzar6afqd2uwt67hrpah3y4laiowd7xm5ldwdbporzkzldnbm7pnjpa: unable to decode branch node entry into []byte at position: 14 value: [[54 67 156 56 255 153 112 176 185 21 62 239 27 79 212 212 90 175 240 252 0 192 203 46 180 91 154 233] [1]], got []interface {}`

One of the branch node elements decodes into two byte arrays instead of the expected single array. While the source of the error is still unknown, this change prevents the error from affecting publishing and indexing of the node. The issue will still be present when we attempt to traverse the storage trie and prove its completeness.

Edit: the error is because when a linked node is less than 32 bytes in length, it is pointed to directly rather than by its hash. https://discord.com/channels/595666850260713488/595721451651465227/709778264259952673